### PR TITLE
Use the env helper to allow config without publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,13 @@ If you want you can use the [facade](http://laravel.com/docs/facades). Add the r
 'GitLab' => Vinkla\GitLab\Facades\GitLab::class
 ```
 
-## Configuration
+## Default Configuration
 
-Laravel GitLab requires connection configuration. To get started, you'll need to publish all vendor assets:
+You can easily configure Laravel GitLab by setting the `GITLAB_TOKEN` and `GITLAB_BASE_URL` environment variables. This is recommended if your organization uses a single GitLab server.
+
+## Custom Configuration
+
+If you'd like to override the default config, you'll need to publish all vendor assets:
 
 ```bash
 php artisan vendor:publish

--- a/config/gitlab.php
+++ b/config/gitlab.php
@@ -38,8 +38,8 @@ return [
     'connections' => [
 
         'main' => [
-            'token' => 'your-token',
-            'base_url' => 'http://git.yourdomain.com/api/v3/',
+            'token' => env('GITLAB_TOKEN', 'your-token'),
+            'base_url' => env('GITLAB_BASE_URL', 'http://git.yourdomain.com/api/v3/'),
         ],
 
         'alternative' => [


### PR DESCRIPTION
Currently, publishing the config is required to setup laravel-gitlab. This merge request permits the user to simply set the `GITLAB_TOKEN` and `GITLAB_BASE_URL` environment variables without publishing. Note, this works without any other changes because the `mergeConfigFrom` method is already being called in the service provider.