### PR TITLE
Allow use with Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/contracts": "5.3.* || 5.4.*",
-        "illuminate/support": "5.3.* || 5.4.*",
+        "illuminate/contracts": "5.3.* || 5.4.* || 5.5.*",
+        "illuminate/support": "5.3.* || 5.4.* || 5.5.*",
         "graham-campbell/manager": "^2.5",
         "m4tthumphrey/php-gitlab-api": "^8.0"
     },


### PR DESCRIPTION
Laravel 5.5 isn't released yet, but lots of people (including me) are already using it. This PR allows the use of this package with Laravel 5.5

Also, please release a new version of this package (you can release a patch or a minor version) when you merge this PR, to avoid pulling `dev-master`.