### PR TITLE
Define concrete provider in vendor publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If you want you can use the [facade](http://laravel.com/docs/facades). Add the r
 Laravel GitLab requires connection configuration. To get started, you'll need to publish all vendor assets:
 
 ```bash
-$ php artisan vendor:publish
+$ php artisan vendor:publish --provider="Vinkla\GitLab\GitLabServiceProvider"
 ```
 
 This will create a `config/gitlab.php` file in your app that you can modify to set your configuration. Also, make sure you check for changes to the original config file in this package between releases.


### PR DESCRIPTION
Call `vendor:publish` for concrete provider to prevent publishing for unintended publishes of other packages providers.